### PR TITLE
fix: fix the meaning of the state

### DIFF
--- a/aristoteles/aristoteles.py
+++ b/aristoteles/aristoteles.py
@@ -50,9 +50,9 @@ _DAY_LIMIT = arrow.get("2000-01-01")
 
 
 def write_state(conf, value):
-    """Write value (an arrow) to state file"""
+    """Write tommorrow relative to value (an arrow) to state file"""
     with open(conf["state_path"], "w") as f:
-        f.write(value.format("YYYYMMDD"))
+        f.write(value.shift(days=1).format("YYYYMMDD"))
 
 
 def read_state(conf):
@@ -191,7 +191,9 @@ def entry():
             # advance to that day
             if arg.reset_state < first_day:
                 arg.reset_state = first_day
-            write_state(conf, arg.reset_state)
+
+            # Today is tomorrow's yesterday
+            write_state(conf, arg.reset_state.shift(days=-1))
         else:
             print("State present.  Use --force to overwrite.")
         exit(0)


### PR DESCRIPTION
There was confusion in the code over whether the state file contained
(a) the last day successfully written, in which case aristoteles should
start writing the subsequent day, or (b) the earliest day not yet
written, in which case aristotles should start with the day in the file.

The code now consistently uses interpretation (b).